### PR TITLE
Disconnect

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,3 @@
 # TODO
 * Error messages
 * OpenSlides4
-* Handle websocket disconnect and server shutdown.
- * Backend disconnects
- * wsproxy exists

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,6 @@
 # TODO
 * Error messages
-* Handle websocket disconnect and server shutdown.
 * OpenSlides4
+* Handle websocket disconnect and server shutdown.
+ * Backend disconnects
+ * wsproxy exists

--- a/internal/wsproxy/commands.go
+++ b/internal/wsproxy/commands.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -134,6 +135,9 @@ func readerToChan(r io.Reader) <-chan []byte {
 		}
 		if err := scanner.Err(); err != nil {
 			// TODO handle error
+			if errors.Is(err, context.Canceled) {
+				return
+			}
 			log.Printf("scanner: %v", err)
 			return
 		}

--- a/internal/wsproxy/commands.go
+++ b/internal/wsproxy/commands.go
@@ -78,12 +78,13 @@ func (c *cmdConnect) Call(conn *wsConnection) error {
 
 	go func() {
 		// Read resp.Body until it closes or the context is done.
+		reason := []byte("null")
 		defer resp.Body.Close()
 		defer func() {
-			conn.eventColse(c.id, resp.StatusCode, []byte("null"))
+			conn.eventColse(c.id, resp.StatusCode, reason)
 		}()
 
-		msgChan := readerToChan(resp.Body)
+		msgChan, errChan := readerToChan(resp.Body)
 		for {
 			select {
 			case msg, ok := <-msgChan:
@@ -94,6 +95,13 @@ func (c *cmdConnect) Call(conn *wsConnection) error {
 
 			case <-conn.ctx.Done():
 				return
+			case err := <-errChan:
+				var closedErr backendClosedError
+				if errors.As(err, &closedErr) {
+					reason = []byte("connection to backend lost")
+					return
+				}
+				log.Printf("Error reading from backend: %v", err)
 			}
 		}
 	}()
@@ -125,8 +133,9 @@ func (c *cmdClose) Call(conn *wsConnection) error {
 	return nil
 }
 
-func readerToChan(r io.Reader) <-chan []byte {
+func readerToChan(r io.Reader) (<-chan []byte, <-chan error) {
 	c := make(chan []byte, 1)
+	errChan := make(chan error)
 	go func() {
 		defer close(c)
 		scanner := bufio.NewScanner(r)
@@ -138,9 +147,11 @@ func readerToChan(r io.Reader) <-chan []byte {
 			if errors.Is(err, context.Canceled) {
 				return
 			}
-			log.Printf("scanner: %v", err)
+			errChan <- fmt.Errorf("scanner: %w", err)
 			return
 		}
+		errChan <- backendClosedError{}
+
 	}()
-	return c
+	return c, errChan
 }

--- a/internal/wsproxy/error.go
+++ b/internal/wsproxy/error.go
@@ -1,0 +1,7 @@
+package wsproxy
+
+type backendClosedError struct{}
+
+func (err backendClosedError) Error() string {
+	return "connection to backend is closed"
+}


### PR DESCRIPTION
This PR handels the case, that the backend is closed, wsproxy is closed or a client closes the websocket connection.

@FinnStutzenstein When the backend (for example the autoupdate-service) closes, I send the following message to the client gets the following message:
```
{"event":"close","id":1,"code":200,"reason":connection to backend lost}
```
Is the reason ok? I am not sure if this is an internal error, that should not be sent to the client. The alternative is, that the reason is empty.

Could you also test, that the shutdown of wsproxy works correctly? What I want is, that on shutdown, the service sends a websocket-close-frame to all open websocket connections and waits until it gets a close-frame back. It seems to work, but I don't have the tools to test it. Please tell me, I you find any problems on shutdown of any component.